### PR TITLE
Fix legacy Link usage

### DIFF
--- a/src/presentation/components/organisms/Header.tsx
+++ b/src/presentation/components/organisms/Header.tsx
@@ -14,25 +14,25 @@ export function Header() {
       <NavigationMenu>
         <NavigationMenuList>
           <NavigationMenuItem>
-            <Link href="/" passHref legacyBehavior>
-              <NavigationMenuLink className="font-medium">
+            <NavigationMenuLink asChild>
+              <Link href="/" className="font-medium">
                 Home
-              </NavigationMenuLink>
-            </Link>
+              </Link>
+            </NavigationMenuLink>
           </NavigationMenuItem>
           <NavigationMenuItem>
-            <Link href="/videos" passHref legacyBehavior>
-              <NavigationMenuLink className="font-medium">
+            <NavigationMenuLink asChild>
+              <Link href="/videos" className="font-medium">
                 Videos
-              </NavigationMenuLink>
-            </Link>
+              </Link>
+            </NavigationMenuLink>
           </NavigationMenuItem>
           <NavigationMenuItem>
-            <Link href="/live" passHref legacyBehavior>
-              <NavigationMenuLink className="font-medium">
+            <NavigationMenuLink asChild>
+              <Link href="/live" className="font-medium">
                 Live
-              </NavigationMenuLink>
-            </Link>
+              </Link>
+            </NavigationMenuLink>
           </NavigationMenuItem>
         </NavigationMenuList>
       </NavigationMenu>

--- a/src/presentation/components/ui/navigation-menu.tsx
+++ b/src/presentation/components/ui/navigation-menu.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';
 import { cva } from 'class-variance-authority';
 import { ChevronDownIcon } from 'lucide-react';
@@ -123,10 +126,15 @@ function NavigationMenuViewport({
 
 function NavigationMenuLink({
   className,
+  asChild = false,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Link> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot : NavigationMenuPrimitive.Link;
+
   return (
-    <NavigationMenuPrimitive.Link
+    <Comp
       data-slot="navigation-menu-link"
       className={cn(
         "data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",


### PR DESCRIPTION
## Summary
- modernize `NavigationMenu` to a client component
- support `asChild` in `NavigationMenuLink`
- refactor `Header` to use new Link pattern

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6860e7e84a04833198ff9a9a74082a5e