### PR TITLE
Enable Livepeer API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ FIREBASE_SERVICE_ACCOUNT_JSON='{"type": "...", ...}'
 NEXT_PUBLIC_FIREBASE_CONFIG='{"apiKey":"...", ...}'
 ```
 
+### 動画配信・ライブ配信の利用方法
+
+1. [Livepeer Studio](https://www.livepeer.studio/) にサインアップし、API キーを取得して `LIVEPEER_API_KEY` に設定します。
+2. ダッシュボードから動画をアップロードするとアセット ID が発行されます。`/video/<id>` ページにアクセスすると再生を確認できます。
+3. ライブ配信を行う場合は Livepeer でストリームを作成し、取得したストリーム ID を `/live/<id>` に指定します。OBS などの配信ソフトからストリームの Ingest URL に送信するとそのまま視聴できます。
+
 ---
 
 ## ⚙️ 開発 & デプロイ

--- a/src/application/services/getLiveStream.ts
+++ b/src/application/services/getLiveStream.ts
@@ -1,10 +1,13 @@
 import type { LiveStream } from '@/domain/liveStream';
 import type { LiveStreamRepository } from '@/domain/liveStreamRepository';
 import { MockLiveStreamRepository } from '@/infrastructure/mockLiveStreamRepository';
+import { LivepeerLiveStreamRepository } from '@/infrastructure/livepeerLiveStreamRepository';
 
 export async function getLiveStream(
   id: string,
-  repo: LiveStreamRepository = new MockLiveStreamRepository()
+  repo: LiveStreamRepository = process.env.LIVEPEER_API_KEY
+    ? new LivepeerLiveStreamRepository()
+    : new MockLiveStreamRepository()
 ): Promise<LiveStream | null> {
   return repo.getById(id);
 }

--- a/src/application/services/getLiveStreams.ts
+++ b/src/application/services/getLiveStreams.ts
@@ -1,9 +1,12 @@
 import type { LiveStream } from '@/domain/liveStream';
 import type { LiveStreamRepository } from '@/domain/liveStreamRepository';
 import { MockLiveStreamRepository } from '@/infrastructure/mockLiveStreamRepository';
+import { LivepeerLiveStreamRepository } from '@/infrastructure/livepeerLiveStreamRepository';
 
 export async function getLiveStreams(
-  repo: LiveStreamRepository = new MockLiveStreamRepository()
+  repo: LiveStreamRepository = process.env.LIVEPEER_API_KEY
+    ? new LivepeerLiveStreamRepository()
+    : new MockLiveStreamRepository()
 ): Promise<LiveStream[]> {
   return repo.list();
 }

--- a/src/application/services/getVideo.ts
+++ b/src/application/services/getVideo.ts
@@ -1,10 +1,13 @@
 import type { Video } from '@/domain/video';
 import type { VideoRepository } from '@/domain/videoRepository';
 import { MockVideoRepository } from '@/infrastructure/mockVideoRepository';
+import { LivepeerVideoRepository } from '@/infrastructure/livepeerVideoRepository';
 
 export async function getVideo(
   id: string,
-  repo: VideoRepository = new MockVideoRepository()
+  repo: VideoRepository = process.env.LIVEPEER_API_KEY
+    ? new LivepeerVideoRepository()
+    : new MockVideoRepository()
 ): Promise<Video | null> {
   return repo.getById(id);
 }

--- a/src/application/services/getVideos.ts
+++ b/src/application/services/getVideos.ts
@@ -1,9 +1,12 @@
 import type { Video } from '@/domain/video';
 import type { VideoRepository } from '@/domain/videoRepository';
 import { MockVideoRepository } from '@/infrastructure/mockVideoRepository';
+import { LivepeerVideoRepository } from '@/infrastructure/livepeerVideoRepository';
 
 export async function getVideos(
-  repo: VideoRepository = new MockVideoRepository()
+  repo: VideoRepository = process.env.LIVEPEER_API_KEY
+    ? new LivepeerVideoRepository()
+    : new MockVideoRepository()
 ): Promise<Video[]> {
   return repo.list();
 }

--- a/src/infrastructure/livepeerLiveStreamRepository.ts
+++ b/src/infrastructure/livepeerLiveStreamRepository.ts
@@ -1,0 +1,53 @@
+import type { LiveStream } from '@/domain/liveStream';
+import type { LiveStreamRepository } from '@/domain/liveStreamRepository';
+
+const API_BASE = 'https://livepeer.studio/api';
+
+export class LivepeerLiveStreamRepository implements LiveStreamRepository {
+  private readonly apiKey = process.env.LIVEPEER_API_KEY;
+
+  private async fetchFromLivepeer(path: string) {
+    if (!this.apiKey) {
+      throw new Error('LIVEPEER_API_KEY is not set');
+    }
+
+    const res = await fetch(`${API_BASE}${path}`, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Livepeer API error: ${res.status}`);
+    }
+
+    return res.json();
+  }
+
+  private toStream(stream: Record<string, unknown>): LiveStream {
+    const data = stream as {
+      id?: string;
+      name?: string;
+      isActive?: boolean;
+      playbackUrl?: string;
+    };
+    return {
+      id: data.id ?? '',
+      title: data.name ?? 'Untitled',
+      isLive: data.isActive ?? false,
+      playbackUrl: data.playbackUrl ?? '',
+    };
+  }
+
+  async list(): Promise<LiveStream[]> {
+    const data = await this.fetchFromLivepeer('/stream');
+    return Array.isArray(data) ? data.map(this.toStream) : [];
+  }
+
+  async getById(id: string): Promise<LiveStream | null> {
+    const stream = await this.fetchFromLivepeer(`/stream/${id}`);
+    if (!stream) return null;
+    return this.toStream(stream);
+  }
+}

--- a/src/infrastructure/livepeerVideoRepository.ts
+++ b/src/infrastructure/livepeerVideoRepository.ts
@@ -1,0 +1,54 @@
+import type { Video } from '@/domain/video';
+import type { VideoRepository } from '@/domain/videoRepository';
+
+const API_BASE = 'https://livepeer.studio/api';
+
+export class LivepeerVideoRepository implements VideoRepository {
+  private readonly apiKey = process.env.LIVEPEER_API_KEY;
+
+  private async fetchFromLivepeer(path: string) {
+    if (!this.apiKey) {
+      throw new Error('LIVEPEER_API_KEY is not set');
+    }
+
+    const res = await fetch(`${API_BASE}${path}`, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Livepeer API error: ${res.status}`);
+    }
+
+    return res.json();
+  }
+
+  private toVideo(asset: Record<string, unknown>): Video {
+    const data = asset as {
+      id?: string;
+      name?: string;
+      playbackUrl?: string;
+      downloadUrl?: string;
+      meta?: { description?: string };
+    };
+    return {
+      id: data.id ?? '',
+      title: data.name ?? 'Untitled',
+      description: data.meta?.description ?? '',
+      url: data.playbackUrl ?? data.downloadUrl ?? '',
+    };
+  }
+
+  async list(): Promise<Video[]> {
+    const data = await this.fetchFromLivepeer('/asset');
+    return Array.isArray(data) ? data.map(this.toVideo) : [];
+  }
+
+  async getById(id: string): Promise<Video | null> {
+    const asset = await this.fetchFromLivepeer(`/asset/${id}`);
+    if (!asset) return null;
+    return this.toVideo(asset);
+  }
+}


### PR DESCRIPTION
## Summary
- add repositories for Livepeer assets and streams
- use Livepeer repositories when `LIVEPEER_API_KEY` is set
- document how to upload videos and start live streams

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686104e6750883319462c3793eef4145